### PR TITLE
Fix: casting error

### DIFF
--- a/Signature.class.php
+++ b/Signature.class.php
@@ -255,7 +255,7 @@ class Signature {
 		// Precalculate (p + 1) / 4 where p is the field order
 		// $p_over_four is GMP
 		static $p_over_four; // XXX just assuming only one curve/prime will be used
-		if (!$p_over_four) {
+		if (null === $p_over_four) {
 			$p_over_four = gmp_div(gmp_add($p, 1), 4);
 		}
 


### PR DESCRIPTION
Fixing error "Object of class GMP could not be converted to bool" during multiple call